### PR TITLE
fix the counting of edges in graph-highlighter

### DIFF
--- a/modules/core/src/structs/graph.ts
+++ b/modules/core/src/structs/graph.ts
@@ -111,6 +111,14 @@ export class Graph extends Node {
     }
     return n
   }
+  /** return the number of all nodes in the graph, including the subgraphs */
+  deepEdgesCount(): number {
+    let count = 0
+    for (const p of this.deepNodes) {
+      count += p.outDegree + p.selfDegree
+    }
+    return count
+  }
 }
 
 export function* shallowConnectedComponents(graph: Graph): IterableIterator<Node[]> {

--- a/modules/renderer/src/layers/graph-highlighter.ts
+++ b/modules/renderer/src/layers/graph-highlighter.ts
@@ -92,7 +92,7 @@ export default class GraphHighlighter {
     }
 
     this._graph = graph.graph
-    const edgeCount = graph.edgeCount
+    const edgeCount = this._graph.deepEdgesCount()
     this._nodeMap = new Map<string, number>()
     this._nodeList = []
     this._hasBidirectionalEdge = false


### PR DESCRIPTION
The was functionality missing to count all the edges of a graph: so the higlighter created a massive that was too short.
Signed-off-by: Lev Nachmanson <levnach@hotmail.com>