### PR TITLE
Remove property overrides in RRect to work properly when compiled to ES5

### DIFF
--- a/modules/core/src/layout/core/RRect.ts
+++ b/modules/core/src/layout/core/RRect.ts
@@ -3,68 +3,39 @@ import {Point} from '../../math/geometry/point'
 import {Curve, CurveFactory} from '../../math/geometry'
 
 export class RRect extends Rectangle {
+  public radX: number
+  public radY: number
+  public roundedRect_: Curve
+  protected boundingBox_: Rectangle
+
+  constructor(t: {left: number; right: number; top: number; bottom: number; radX: number; radY: number}) {
+    super(t)
+
+    this.radX = t.radX
+    this.radY = t.radY
+    this.roundedRect_ = CurveFactory.mkRectangleWithRoundedCorners(this.width, this.height, t.radX, t.radY, this.center)
+  }
+
+  override onUpdated(): void {
+    if (!this.isEmpty) {
+      this.roundedRect_ = CurveFactory.mkRectangleWithRoundedCorners(this.width, this.height, this.radX, this.radY, this.center)
+    }
+  }
+
   isOk(): boolean {
     if (this.isEmpty()) {
       return true
     }
     return this.roundedRect_.boundingBox.equalEps(this)
   }
+
   setRect(value: Rectangle) {
-    super.left_ = value.left
-    super.right_ = value.right
-    super.top_ = value.top
-    super.bottom_ = value.bottom
+    this.left = value.left
+    this.right = value.right
+    this.top = value.top
+    this.bottom = value.bottom
     if (!this.isEmpty()) {
-      this.roundedRect_ = CurveFactory.mkRectangleWithRoundedCorners(value.width, value.height, this.radX, this.radY, super.center)
+      this.roundedRect_ = CurveFactory.mkRectangleWithRoundedCorners(value.width, value.height, this.radX, this.radY, this.center)
     }
-  }
-  radX: number
-  radY: number
-  roundedRect_: Curve
-  boundingBox_: Rectangle
-  constructor(t: {left: number; right: number; top: number; bottom: number; radX: number; radY: number}) {
-    super(t)
-    this.radX = t.radX
-    this.radY = t.radY
-    this.roundedRect_ = CurveFactory.mkRectangleWithRoundedCorners(super.width, super.height, t.radX, t.radY, super.center)
-  }
-  get center() {
-    return super.center
-  }
-  set center(value: Point) {
-    super.center = value
-    this.roundedRect_ = CurveFactory.mkRectangleWithRoundedCorners(super.width, super.height, this.radX, this.radY, super.center)
-    // Assert.assert(this.isOk())
-  }
-  get left() {
-    return super.left
-  }
-  set left(value: number) {
-    super.left = value
-    this.roundedRect_ = CurveFactory.mkRectangleWithRoundedCorners(super.width, super.height, this.radX, this.radY, super.center)
-  }
-  get right(): number {
-    return super.right
-  }
-  set right(value: number) {
-    super.right = value
-    this.roundedRect_ = CurveFactory.mkRectangleWithRoundedCorners(super.width, super.height, this.radX, this.radY, super.center)
-  }
-  get top() {
-    return super.top
-  }
-
-  set top(value: number) {
-    super.top = value
-    this.roundedRect_ = CurveFactory.mkRectangleWithRoundedCorners(super.width, super.height, this.radX, this.radY, super.center) // todo: optimize
-  }
-  get bottom() {
-    return super.bottom
-  }
-
-  set bottom(value: number) {
-    super.bottom = value
-    if (!this.isEmpty)
-      this.roundedRect_ = CurveFactory.mkRectangleWithRoundedCorners(super.width, super.height, this.radX, this.radY, super.center) // todo: optimize
   }
 }

--- a/modules/core/src/math/geometry/rectangle.ts
+++ b/modules/core/src/math/geometry/rectangle.ts
@@ -54,6 +54,7 @@ export class Rectangle implements IRectangle<Point> {
     this.top_ = t.top
     this.bottom = t.bottom
   }
+
   add_rect(rectangle: IRectangle<Point>): IRectangle<Point> {
     return this.addRec(rectangle as unknown as Rectangle)
   }
@@ -131,6 +132,7 @@ export class Rectangle implements IRectangle<Point> {
   }
   set left(value: number) {
     this.left_ = value
+    this.onUpdated()
   }
 
   get right() {
@@ -138,6 +140,7 @@ export class Rectangle implements IRectangle<Point> {
   }
   set right(value: number) {
     this.right_ = value
+    this.onUpdated()
   }
 
   get top() {
@@ -145,6 +148,7 @@ export class Rectangle implements IRectangle<Point> {
   }
   set top(value: number) {
     this.top_ = value
+    this.onUpdated()
   }
 
   get bottom() {
@@ -152,6 +156,7 @@ export class Rectangle implements IRectangle<Point> {
   }
   set bottom(value: number) {
     this.bottom_ = value
+    this.onUpdated()
   }
 
   get leftBottom() {
@@ -185,6 +190,9 @@ export class Rectangle implements IRectangle<Point> {
     this.right_ = value.x
     this.bottom = value.y
   }
+
+  /* eslint-disable  @typescript-eslint/no-empty-function */
+  protected onUpdated(): void {}
 
   // create a box of two points
   static mkPP(point0: Point, point1: Point) {


### PR DESCRIPTION
In typescript you are not allowed to override property setters and call super.property = value. This removes that need, but does so in a bit of an obscure way, curious if there are better ways to do this without modifying other classes too much.