### PR TITLE
Fix import paths

### DIFF
--- a/examples/webgl-renderer/src/app.ts
+++ b/examples/webgl-renderer/src/app.ts
@@ -1,5 +1,6 @@
 import {dropZone} from './drag-n-drop'
-import {Renderer as WebGLRenderer, SearchControl, LayoutOptions} from '@msagl/renderer-webgl'
+import {LayoutOptions} from '@msagl/renderer-common'
+import {Renderer as WebGLRenderer, SearchControl} from '@msagl/renderer-webgl'
 
 import {EdgeRoutingMode, geometryIsCreated, Graph} from 'msagl-js'
 

--- a/modules/core/src/routing/spline/bundling/MetroGraphData.ts
+++ b/modules/core/src/routing/spline/bundling/MetroGraphData.ts
@@ -4,7 +4,7 @@
 //
 //  'real' edges are original graph edges
 
-import {Port} from '../../../../src/layout/core/port'
+import {Port} from '../../../layout/core/port'
 import {Stack} from 'stack-typescript'
 import {GeomEdge, Point} from '../../..'
 import {Polyline, Curve, PointLocation} from '../../../math/geometry'

--- a/modules/renderer-common/src/index.ts
+++ b/modules/renderer-common/src/index.ts
@@ -1,11 +1,11 @@
 import {EdgeRoutingMode} from 'msagl-js'
 import {TextMeasurerOptions} from 'msagl-js/drawing'
-import {layoutGraph} from './layout'
-import TextMeasurer from './text-measurer'
-import {deepEqual, getLabelPosition} from './utils'
-import initLayoutWorker from './workers/layoutWorker'
 
-export {deepEqual, getLabelPosition, TextMeasurer, layoutGraph, initLayoutWorker}
+export {layoutGraph, layoutGraphOnWorker} from './layout'
+export {default as TextMeasurer} from './text-measurer'
+export {deepEqual, getLabelPosition} from './utils'
+export {default as initLayoutWorker} from './workers/layoutWorker'
+
 export type LayoutOptions = {
   layoutType?: 'Sugiyama LR' | 'Sugiyama TB' | 'Sugiyama BT' | 'Sugiyama RL' | 'IPsepCola' | 'MDS'
   label?: Partial<TextMeasurerOptions>

--- a/modules/renderer-common/tsconfig.prod.json
+++ b/modules/renderer-common/tsconfig.prod.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "lib": ["dom", "es2018"],
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "composite": true
   },
   "references": [
     {

--- a/modules/renderer-svg/tsconfig.prod.json
+++ b/modules/renderer-svg/tsconfig.prod.json
@@ -8,6 +8,9 @@
   "references": [
     {
       "path": "../core/tsconfig.prod.json"
+    },
+    {
+      "path": "../renderer-common/tsconfig.prod.json"
     }
   ],
   "include": ["src/**/*"]

--- a/modules/renderer-webgl/src/renderer.ts
+++ b/modules/renderer-webgl/src/renderer.ts
@@ -7,17 +7,15 @@ import {DrawingGraph} from 'msagl-js/drawing'
 
 import GraphLayer from './layers/graph-layer'
 
-import {layoutGraph, layoutGraphOnWorker} from '@msagl/renderer-common/src/layout'
+import {layoutGraph, layoutGraphOnWorker, LayoutOptions, deepEqual, TextMeasurer} from '@msagl/renderer-common'
 import {Graph, GeomGraph, Rectangle, GeomNode, TileMap, TileData, geometryIsCreated} from 'msagl-js'
 
 import {Matrix4} from '@math.gl/core'
 
 import EventSource, {Event} from './event-source'
-import {deepEqual, TextMeasurer} from '@msagl/renderer-common'
 
 import GraphHighlighter from './layers/graph-highlighter'
 import {getIconAtlas} from './layers/arrows'
-import {LayoutOptions} from '@msagl/renderer-common/src'
 
 export interface IRendererControl {
   onAdd(renderer: Renderer): void

--- a/modules/renderer-webgl/tsconfig.prod.json
+++ b/modules/renderer-webgl/tsconfig.prod.json
@@ -8,6 +8,9 @@
   "references": [
     {
       "path": "../core/tsconfig.prod.json"
+    },
+    {
+      "path": "../renderer-common/tsconfig.prod.json"
     }
   ],
   "include": ["src/**/*"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,10 @@
     "paths": {
       "msagl-js": ["./modules/core/src"],
       "msagl-js/drawing": ["./modules/core/src/drawing"],
-      "@msagl/parser": ["./modules/parser/src"]
+      "@msagl/parser": ["./modules/parser/src"],
+      "@msagl/renderer-common": ["./modules/renderer-common/src"],
+      "@msagl/renderer-svg": ["./modules/renderer-svg/src"],
+      "@msagl/renderer-webgl": ["./modules/renderer-webgl/src"]
     }
   },
   "include": [


### PR DESCRIPTION
Do not import from subpaths under a module name, e.g. `@msagl/renderer-common/src/layout`. It's not going to work when you publish.