### PR TITLE
Update ShapeObstacleCalculator.ts to import Node

### DIFF
--- a/modules/core/src/routing/ShapeObstacleCalculator.ts
+++ b/modules/core/src/routing/ShapeObstacleCalculator.ts
@@ -12,6 +12,7 @@ import {flattenArray} from '../utils/setOperations'
 import {InteractiveObstacleCalculator} from './interactiveObstacleCalculator'
 import {Shape} from './shape'
 import {TightLooseCouple} from './TightLooseCouple'
+import {Node} from '../structs/node'
 
 export class ShapeObstacleCalculator {
   tightHierarchy: RectangleNode<Polyline, Point>


### PR DESCRIPTION
When building a library which uses @msagl/core I get the following error:

```
../../node_modules/@msagl/core/dist/routing/ShapeObstacleCalculator.d.ts:10:46 - error TS2304: Cannot find name 'Node'.

10     loosePolylinesToNodes: Map<Polyline, Set<Node>>;
                                                ~~~~


Found 1 error in ../../node_modules/@msagl/core/dist/routing/ShapeObstacleCalculator.d.ts:10
```

There's a reference to `Node` in `ShapeObstacleCalculator` that isn't imported in the actual file.  Additionally, without this import, VSCode assumes Node is the one from the TS DOM.