### PR TITLE
docs: remove extra period in package install instructions

### DIFF
--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -20,7 +20,7 @@ npm install @msagl/core
 If you use the SVG renderer, you need to install @msagl/renderer-svg:
 
 ```bash npm2yarn
-npm install @msagl/renderer-svg.
+npm install @msagl/renderer-svg
 ```
 
 If you use the Deck.gl renderer, you need to install @msagl/renderer-webgl:


### PR DESCRIPTION
This PR fixes an issue in the documentation where the npm install command for the @msagl/renderer-svg package had an extra period at the end.