### PR TITLE
Deploy GitHub Pages only from dev branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,9 +5,9 @@ name: Test Status
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 jobs:
   build:
@@ -43,7 +43,7 @@ jobs:
           yarn build:docs
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
-        if: ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/dev' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: website/build


### PR DESCRIPTION
Updates test.yml so GitHub Pages is deployed only from the dev branch (condition changed from refs/heads/main to refs/heads/dev) and adds dev to the push/PR trigger branches.